### PR TITLE
Update instructions for bor v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2
 To run actual playbook on validator node:
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry"
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry"
 ```
 
 ### Check sync status
@@ -164,13 +164,13 @@ ansible-playbook -l <group-name> --extra-var="heimdall_branch=v0.2.0-mainnet-1d8
 **To setup Bor**
 
 ```bash
-ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.3" playbooks/bor.yml
+ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.6" playbooks/bor.yml
 ```
 
 To show list of hosts where the playbook will run:
 
 ```bash
-ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.3" playbooks/bor.yml --list-hosts
+ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.6" playbooks/bor.yml --list-hosts
 ```
 
 ### Adhoc queries

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ While running Ansible playbook, `network_version` needs to be set.
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
 ```
 
 To run actual playbook on sentry nodes:
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
 ```
 
 ### Validator node setup (with sentry)
@@ -80,13 +80,13 @@ ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.3 
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
 ```
 
 To run actual playbook on validator node:
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
 ```
 
 ### Validator node setup (with-out sentry)
@@ -94,7 +94,7 @@ ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
 ```
 
 To run actual playbook on validator node:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ While running Ansible playbook, `network_version` needs to be set.
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
 ```
 
 To run actual playbook on sentry nodes:
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
 ```
 
 ### Validator node setup (with sentry)
@@ -80,13 +80,13 @@ ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.4 
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
 ```
 
 To run actual playbook on validator node:
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
 ```
 
 ### Validator node setup (with-out sentry)
@@ -94,7 +94,7 @@ ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.4 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.6 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
 ```
 
 To run actual playbook on validator node:

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ While running Ansible playbook, `network_version` needs to be set.
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry" --list-hosts
 ```
 
 To run actual playbook on sentry nodes:
 
 ```bash
-ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
+ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/sentry"
 ```
 
 ### Validator node setup (with sentry)
@@ -80,13 +80,13 @@ ansible-playbook -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.1 
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator" --list-hosts
 ```
 
 To run actual playbook on validator node:
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=sentry/validator"
 ```
 
 ### Validator node setup (with-out sentry)
@@ -94,13 +94,13 @@ ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2
 To show list of hosts where the playbook will run (notice `--list-hosts` at the end):
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry" --list-hosts
 ```
 
 To run actual playbook on validator node:
 
 ```bash
-ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.1 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry"
+ansible-playbook -l validator playbooks/network.yml --extra-var="bor_branch=v0.2.3 heimdall_branch=v0.2.0-mainnet-1d8aca37 network_version=mainnet-v1 node_type=without-sentry"
 ```
 
 ### Check sync status
@@ -164,13 +164,13 @@ ansible-playbook -l <group-name> --extra-var="heimdall_branch=v0.2.0-mainnet-1d8
 **To setup Bor**
 
 ```bash
-ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.1" playbooks/bor.yml
+ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.3" playbooks/bor.yml
 ```
 
 To show list of hosts where the playbook will run:
 
 ```bash
-ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.1" playbooks/bor.yml --list-hosts
+ansible-playbook -l <group-name> --extra-var="bor_branch=v0.2.3" playbooks/bor.yml --list-hosts
 ```
 
 ### Adhoc queries


### PR DESCRIPTION
Current instructions fail for v0.2.1

`fatal: [3.237.99.90]: FAILED! => {"changed": true, "cmd": ["make", "bor-all"], "delta": "0:00:00.002944", "end": "2021-01-27 16:13:48.672532", "msg": "non-zero return code", "rc": 2, "start": "2021-01-27 16:13:48.669588", "stderr": "make: *** No rule to make target 'bor-all'.  Stop.", "stderr_lines": ["make: *** No rule to make target 'bor-all'.  Stop."], "stdout": "", "stdout_lines": []}`