### PR TITLE
changed the go installer gist and bor make command

### DIFF
--- a/roles/install-bor/tasks/main.yml
+++ b/roles/install-bor/tasks/main.yml
@@ -9,7 +9,7 @@
     version: "{{ bor_branch }}"
 
 - name: Build Bor
-  command: chdir={{ ansible_env.HOME }}/bor make bor-all
+  command: chdir={{ ansible_env.HOME }}/bor make all
 
 - name: Creating symlink for bor
   file:

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Download go installer
   get_url:
-    url: https://gist.githubusercontent.com/jdkanani/e18e14910652ad829fad994e4b89f0b9/raw/036bec312799cec8589360d0d939cc5ec0e7f719/go-install.sh
+    url: https://gist.githubusercontent.com/ssandeep/a6c7197811c83c71e5fead841bab396c/raw/e38212982ab8cdfc11776fa1a3aaf92b69e1cb15/go-install.sh
     dest: "{{ ansible_env.HOME }}/go-install.sh"
 
 - name: Execute the go-install.sh


### PR DESCRIPTION
Please check if bor make command needs to change, I changed it as I was getting this error earlier:

```
TASK [install-bor : Build Bor]
***********************************************************************************************************************************************************************************
fatal: [18.184.195.222]: FAILED! => {"changed": true, "cmd": ["make", "bor-all"],
"delta": "0:00:00.002775", "end": "2021-02-23 10:33:48.167754", "msg": "non-zero return code", "rc": 2, "start": "2021-02-23 10:33:48.164979",
"stderr": "make: *** No rule to make target 'bor-all'.  Stop.", "stderr_lines": ["make: *** No rule to make target 'bor-all'.  Stop."], "stdout": "", "stdout_lines": []}
```