### PR TITLE
Cleaning symlinks on running clean.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .workspace
+bin/
+lib/

--- a/inventory.yml
+++ b/inventory.yml
@@ -4,7 +4,7 @@ all:
   children:
     sentry:
       hosts:
-       :
+       54.243.206.185:
     validator:
       hosts:
-        :
+        1.1.1.1:

--- a/playbooks/clean.yml
+++ b/playbooks/clean.yml
@@ -31,3 +31,46 @@
       tags:
         - bor
         - clean
+
+    - name: Remove heimdall symlink
+      file:
+        path: "/usr/bin/heimdalld"
+        state: absent
+      become: true
+
+    - name: Remove bridge symlink
+      file:
+        path: "/usr/bin/bridge"
+        state: absent
+      become: true
+
+    - name: Remove bridge symlink
+      file:
+        path: "/usr/bin/bridge"
+        state: absent
+      become: true
+
+    - name: Remove bor symlink
+      file:
+        path: "/usr/bin/bor"
+        state: absent
+      become: true
+
+    - name: Remove bootnode symlink
+      file:
+        path: "/usr/bin/bootnode"
+        state: absent
+      become: true
+
+    - name: Remove heimdallcli symlink
+      file:
+        path: "/usr/bin/heimdallcli"
+        state: absent
+      become: true
+
+
+
+ 
+
+
+


### PR DESCRIPTION
Earlier all the symlinks created during first run of network.yml file wasn't being removed and If a user runs the network.yml again. it was failing with this error 
```
refusing to convert from file to symlink 
```
for every symlink that was created during the first run. This pull request has tasks to delete those symlinks in clean.yml file. 