### PR TITLE
Update golang install script

### DIFF
--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Download go installer
   get_url:
-    url: https://gist.githubusercontent.com/ssandeep/a6c7197811c83c71e5fead841bab396c/raw/e38212982ab8cdfc11776fa1a3aaf92b69e1cb15/go-install.sh
+    url: https://gist.githubusercontent.com/ssandeep/a6c7197811c83c71e5fead841bab396c/raw/5866fbd95fe3d9eae7bae08a842240d2edbe489e/go-install.sh
     dest: "{{ ansible_env.HOME }}/go-install.sh"
 
 - name: Execute the go-install.sh


### PR DESCRIPTION
Bor v0.2.9 now requires a higher version of golang to be installed.
This bump the golang version to 1.17 which supports the latest version of bor.