### PR TITLE
Updated install-gcp.sh to work with newer versions of Bor

### DIFF
--- a/install-gcp.sh
+++ b/install-gcp.sh
@@ -75,18 +75,18 @@ function configure_node() {
   http_port="${1}"
   HEIMDALLD_CONFIG="/root/.heimdalld/config/config.toml"
   BOR_START_SH="/root/node/bor/start.sh"
-  sed -i 's/^seeds =.*/seeds ="f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656,2eadba4be3ce47ac8db0a3538cb923b57b41c927@35.199.4.13:26656,3b23b20017a6f348d329c102ddc0088f0a10a444@35.221.13.28:26656,25f5f65a09c56e9f1d2d90618aa70cd358aa68da@35.230.116.151:26656"/g' "${HEIMDALLD_CONFIG}"
+  sed -i 's/^seeds =.*/seeds ="f4f605d60b8ffaaf15240564e58a81103510631c@159.203.9.164:26656,4fb1bc820088764a564d4f66bba1963d47d82329@44.232.55.71:26656"/g' "${HEIMDALLD_CONFIG}"
   sed -i 's/^prometheus =.*/prometheus = true/g' "${HEIMDALLD_CONFIG}"
   sed -i 's/^max_open_connections =.*/max_open_connections = 100/g' "${HEIMDALLD_CONFIG}"
   if ! grep -q bootnodes "${BOR_START_SH}"; then
-    echo '  --bootnodes "enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303,enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303,enode://3178257cd1e1ab8f95eeb7cc45e28b6047a0432b2f9412cff1db9bb31426eac30edeb81fedc30b7cd3059f0902b5350f75d1b376d2c632e1b375af0553813e6f@35.221.13.28:30303,enode://16d9a28eadbd247a09ff53b7b1f22231f6deaf10b86d4b23924023aea49bfdd51465b36d79d29be46a5497a96151a1a1ea448f8a8666266284e004306b2afb6e@35.199.4.13:30303,enode://ef271e1c28382daa6ac2d1006dd1924356cfd843dbe88a7397d53396e0741ca1a8da0a113913dee52d9071f0ad8d39e3ce87aa81ebc190776432ee7ddc9d9470@35.230.116.151:30303"' >> "${BOR_START_SH}"
+    echo '  --bootnodes "enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303,enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303"' >> "${BOR_START_SH}"
   fi
   sed -i 's/--http.port.*/--http.port '${http_port}' \\/g' "${BOR_START_SH}"
 }
 
 function sentry_node_setup() {
   cd ${INSTALL_DIR}
-  ansible-playbook --connection=local -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.7 heimdall_branch=v0.2.2 network_version=mainnet-v1 node_type=sentry/sentry heimdall_network=mainnet"
+  ansible-playbook --connection=local -l sentry playbooks/network.yml --extra-var="bor_branch=v0.2.12-beta3 heimdall_branch=v0.2.4  network_version=mainnet-v1 node_type=sentry/sentry heimdall_network=mainnet"
 }
 
 function get_snapshot_url() {


### PR DESCRIPTION
I've updated the `install-gcp.sh` script to follow the instructions for a [full node deployment](https://docs.polygon.technology/docs/integrate/full-node-deployment/). This will should allow people to follow the [Google Cloud SImple Deploy](https://docs.polygon.technology/docs/validate/validate/install-gcp/) and get a working node.

