### PR TITLE
Uncomment the private_key_file in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,7 +6,7 @@ inventory = ./inventory.yml
 host_key_checking = False
 remote_user = ubuntu
 deprecation_warnings=False
-#private_key_file  = .workspace/private.pem
+private_key_file  = .workspace/private.pem
 ansible_ssh_private_key_file: /home/user/id_rsa
 ansible_connection: ssh
 ansible_ssh_user: ubuntu


### PR DESCRIPTION
https://github.com/maticnetwork/node-ansible#setup mentions to "Copy pem private key file as .workspace/private.pem to enable ssh through ansible."
But since this line is commented, `ansible sentry -m ping` results in
```
<IP_ADDR> | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh: ubuntu@<IP_ADDR>: Permission denied (publickey).",
    "unreachable": true
}
```