### PR TITLE
Minor curl change

### DIFF
--- a/go-install.sh
+++ b/go-install.sh
@@ -83,7 +83,7 @@ echo "Downloading $PACKAGE_NAME ..."
 if hash wget 2>/dev/null; then
     wget https://go.dev/dl/$PACKAGE_NAME -O /tmp/go.tar.gz
 else
-    curl -o /tmp/go.tar.gz https://go.dev/dl/$PACKAGE_NAME
+    curl -L -o /tmp/go.tar.gz https://go.dev/dl/$PACKAGE_NAME
 fi
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
The curl fallback in this script doesn't seem to work because it doesn't follow redirects. The script by defaull pulls:

https://go.dev/dl/go1.18.1.linux-amd64.tar.gz

That URL will 302 to:

https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz

I'm adding the `-L` switch to follow the redirect rather than writing the redirect to the gzip file.