### PR TITLE
chg : use go v1.20.7

### DIFF
--- a/go-install.sh
+++ b/go-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.19"
+VERSION="1.20.7"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"


### PR DESCRIPTION
Use golang v1.20.7 in `go-install.sh`. This `go-install.sh` is also used by express-cli/matic-cli. 