### PR TITLE
Addressed a few issues, see description in PR

### DIFF
--- a/playbooks/setup-exporters.yml
+++ b/playbooks/setup-exporters.yml
@@ -1,4 +1,5 @@
 ---
+# arm64 support coming.
 - name: Setup prometheus exporters
   hosts: all
   tasks:

--- a/playbooks/snapshot-restore.yml
+++ b/playbooks/snapshot-restore.yml
@@ -1,0 +1,12 @@
+---
+# ansible-playbook -i inventory.yml playbooks/snapshot-restore.yml -e "network=$network client=$client"
+# Networks: mumbai and mainnet
+# clients: bor and heimdall. Technically you can use erigon but will be plugging that in soon enough.
+# On the host, you can find the screen session with the below command:
+# ps -ef | grep -i screen
+# each session is screen$client, snapbor, snapheimdall, etc.
+- name: snapshot restore
+  hosts: all
+  become: true
+  roles:
+    - snapshot-restore

--- a/roles/install-bor/tasks/main.yml
+++ b/roles/install-bor/tasks/main.yml
@@ -14,12 +14,55 @@
   become: true
 
 - name: add mainnet bootnodes
-  shell: sed -i 's|.*bootnodes =.*|    bootnodes = ["enode://0cb82b395094ee4a2915e9714894627de9ed8498fb881cec6db7c65e8b9a5bd7f2f25cc84e71e89d0947e51c76e85d0847de848c7782b13c0255247a6758178c@44.232.55.71:30303","enode://88116f4295f5a31538ae409e4d44ad40d22e44ee9342869e7d68bdec55b0f83c1530355ce8b41fbec0928a7d75a5745d528450d30aec92066ab6ba1ee351d710@159.203.9.164:30303","enode://4be7248c3a12c5f95d4ef5fff37f7c44ad1072fdb59701b2e5987c5f3846ef448ce7eabc941c5575b13db0fb016552c1fa5cca0dda1a8008cf6d63874c0f3eb7@3.93.224.197:30303","enode://32dd20eaf75513cf84ffc9940972ab17a62e88ea753b0780ea5eca9f40f9254064dacb99508337043d944c2a41b561a17deaad45c53ea0be02663e55e6a302b2@3.212.183.151:30303"]|g' /var/lib/bor/config.toml
+  shell: sed -i 's|.*bootnodes =.*|    bootnodes = ["enode://b8f1cc9c5d4403703fbf377116469667d2b1823c0daf16b7250aa576bacf399e42c3930ccfcb02c5df6879565a2b8931335565f0e8d3f8e72385ecf4a4bf160a@3.36.224.80:30303", "enode://8729e0c825f3d9cad382555f3e46dcff21af323e89025a0e6312df541f4a9e73abfa562d64906f5e59c51fe6f0501b3e61b07979606c56329c020ed739910759@54.194.245.5:30303"]|g' /var/lib/bor/config.toml
   when: network == "mainnet"
   become: true
 
 - name: add mumbai bootnodes
-  shell: sed -i 's|.*bootnodes =.*|    bootnodes = ["enode://320553cda00dfc003f499a3ce9598029f364fbb3ed1222fdc20a94d97dcc4d8ba0cd0bfa996579dcc6d17a534741fb0a5da303a90579431259150de66b597251@54.147.31.250:30303","enode://f0f48a8781629f95ff02606081e6e43e4aebd503f3d07fc931fad7dd5ca1ba52bd849a6f6c3be0e375cf13c9ae04d859c4a9ae3546dc8ed4f10aa5dbb47d4998@34.226.134.117:30303"]|g' /var/lib/bor/config.toml
+  shell: sed -i 's|.*bootnodes =.*|    bootnodes = ["enode://bdcd4786a616a853b8a041f53496d853c68d99d54ff305615cd91c03cd56895e0a7f6e9f35dbf89131044e2114a9a782b792b5661e3aff07faf125a98606a071@43.200.206.40:30303", "enode://209aaf7ed549cf4a5700fd833da25413f80a1248bd3aa7fe2a87203e3f7b236dd729579e5c8df61c97bf508281bae4969d6de76a7393bcbd04a0af70270333b3@54.216.248.9:30303"]|g' /var/lib/bor/config.toml
   when: network == "mumbai"
   become: true
 
+- name: add mumbai static-nodes
+  shell: sed -i 's|.*static-nodes =.*|   static-nodes = ["enode://0b311bc1643dd4e4a9e55a6e40e2f005ac7e85223429d705e9c2cd3209846e029f2f854d3a33e0a718d5cbad83ecdf6fb6937894568bf675ee85af9cf73a89c5@52.214.83.78:30303", "enode://2c400bba0f576736bcc3fb4292c18014bdcfd080e151a330ca163eb6668096eebe65f9e62b346eb031c1da585cd87f93f0df7eee0fcf7709a1ee71388b0f71c4@34.240.114.47:30303", "enode://c121f76915af47d0740474b0ce02b670b084cea3be37b93436810bfac84f0abeecec4be6ae44fe30faeb1b513566ea871422e971fcff2271ae58e3b401cc1502@54.170.47.95:30303", "enode://a57171485aea5b72c244fe6dd6247a7db610638dcece54547fe6a0b8b30212357b672baab550ed26dffe78c0e925b01a08a118396c6660879234aa8284fadbd2@54.194.216.201:30303", "enode://170d08178230a99c4171824fc8c1572e46c9e8ad65194caeeb5c3609a55fab0c6ef24d487991e0cdb8ebd200742c495c0a56804d239c659f5d856e3e88cc7d2e@15.165.109.50:30303", "enode://dfd9dddc584608ad6cfecf0ac67148f702afde63a4e1ec035c01d396ef596553945f6ec051ade901646e23baae2f85977be6a1c8c0718ed011b9c36e34a45fd3@3.37.26.115:30303", "enode://ffea8a9576c3d61fbfb141c65e077ea551e75fb30a91567805e45e80904a1b10294ec81f31b901eafa8785886f73c339f37dc6bd6389e71403fea84f40a2d8f3@43.201.135.93:30303", "enode://8b63e044dac9476c207c2684e431f80fd621d6380f7f19bb2a93a3f6ab99af0bd624c7aedb27978c12189d18371d1d6f5f67cdbe552899bf01449c445cb6ba0b@34.255.201.83:30303" ]|g' /var/lib/bor/config.toml
+  when: network == "mumbai"
+  become: true
+
+- name: add mainnet static-nodes
+  shell: sed -i 's|.*static-nodes =.*|   static-nodes = [ "enode://ad9180a1468702c7c6a7210544593b4bd444768ca754382d1da92fe9abaf408e58160dc72505936df63ca6afc3052e993cade199fe3ff067a5f11b0ee3c6e378@13.209.168.182:30303", "enode://7cf051238a3f92bbee811472a84592ab547ab2692ec09bd2104182551ca6de55f5a7cea48a3d36b411deccb4df976f27076d32019d9ccc4486a916c0e30f3a74@43.201.242.62:30303", "enode://40b4ad081f835ac974472cee8553a455be720263d45d091d395d747c6fa9b615c76e74afe8b9646cddde79ce5fa1dfbfda4d563ab58199681d100c5bbaf7be82@43.202.78.165:30303", "enode://a0da3a49d43404c12a1f350211f4a448cf6715eaa5667813e14e7af88a90820e6b2fb6fcc1a75b0207c19c98c4f6320b4c5c1bdeda408e1fa72710942d4ad6f6@3.38.254.221:30303", "enode://46feaae067017d18cc5c0dee365c970d5004d34e2cf65a82c051b16040b31b1a6714cc14aadc14d95b7c98cc5da3db1d3b8611e19f4ca4e8bee2b0498978c160@15.165.197.16:30303", "enode://fbf7edc7386abc991097687c699e80034518bd3ecc333b0718a49afdf34e93d4ddde377f7210dae4c8e7580e4901d6cbb82a043debe119b71a267c323c6c1ad6@52.78.154.236:30303", "enode://60572bb4659e41d9b2f0a06b2b7c4cf2a7517f2e5e4e49664974bf4c0f52630846f16f190818497d642dcc046698850b689d36d6a9dcd42e388a20e4a46a0de8@52.209.21.164:30303", "enode://71467975c9fbea1d1087693d7af1c8d12bc43029d52c9470b328f7cfe5252475f1886013ddc85ff880b0e7d26b4ce3e33566895ea95d67730e9d91daafbbab2d@99.81.158.129:30303", "enode://4bf816ccbdcd379e4623f65b42b91c18545c1721b58217cbd7258911418f5a112f1f1e01a6580d485844ac2635b3fa1cb6d6c0022319ee5c3a00388aad0b5279@34.254.124.45:30303", "enode://88a7d837d229ec20d9c5805ccb121e2580f2b8b92c3e8b669418addd34f36784ca20d68a672e24ae1daa8862480deed9d73c095b65baa0ce94a6290a1504fd27@34.252.116.193:30303", "enode://a1c1e190a397e351deda6c31faebbd45b459b11cb4ffe63fe894ca4b7860c3c2404ee888f8166c98906f4174c55a64d4f6a2955f6edf3de86d49a5c58e8e955f@54.76.109.39:30303", "enode://0e07395fb40ab63f4f13b0c5630eb94f72f5d4c4b04e5d2c91a1a950a9bfb504889ea9eb811cffb0df55b72883e20e6fde9aba14c9c5d1a48fae18ab3212a7ba@34.246.232.184:30303" ]|g' /var/lib/bor/config.toml
+  when: network == "mainnet"
+  become: true
+
+- name: add values to the maxpeers value
+  ansible.builtin.lineinfile:
+    path: /var/lib/bor/config.toml
+    regexp: '^\s*maxpeers =.*$'
+    line: '\t maxpeers = 50'
+    backrefs: yes
+  when: node_type == "sentry" or "archive"
+  become: true
+
+- name: add values to the max peers value
+  ansible.builtin.lineinfile:
+    path: /var/lib/bor/config.toml
+    regexp: '^\s*maxpeers =.*$'
+    line: '\t maxpeers = 20'
+    backrefs: yes
+  when: node_type == "validator"
+  become: true
+
+- name: add values for max peers for bootnode
+  ansible.builtin.lineinfile:
+    path: /var/lib/bor/config.toml
+    regexp: '^\s*maxpeers =.*$'
+    line: '\t maxpeers = 200'
+    backrefs: yes
+  when: node_type == "bootnode"
+  become: true
+
+- name: start bor service
+  systemd:
+    state: restarted
+    daemon-reload: yes
+    name: bor.service
+  become: true

--- a/roles/install-bor/vars/main.yml
+++ b/roles/install-bor/vars/main.yml
@@ -3,5 +3,5 @@
 
 network: mainnet
 node_type: sentry
-bor_version: v0.3.0
-heimdall_version: v0.3.0
+bor_version: v1.2.3
+heimdall_version: v1.0.3

--- a/roles/install-dependencies/tasks/main.yml
+++ b/roles/install-dependencies/tasks/main.yml
@@ -6,18 +6,6 @@
     update_cache: yes
   become: true
 
-- name: Install build-essential
-  action: apt pkg=build-essential
-  become: true
-
-- name: Install jq
-  action: apt pkg=jq
-  become: true
-  
-- name: Install git
-  action: apt pkg=git
-  become: true
-
 - name: Install rabbitmq-server
   apt:
     name: rabbitmq-server

--- a/roles/install-heimdall/tasks/main.yml
+++ b/roles/install-heimdall/tasks/main.yml
@@ -15,11 +15,91 @@
   when: network == "mumbai"
   become: true
 
+- name: update the persistent peers for mainnet heimdall
+  shell: sed -i 's|^persistent_peers =.*|persistent_peers = "1500161dd491b67fb1ac81868952be49e2509c9f@52.78.36.216:26656,dd4a3f1750af5765266231b9d8ac764599921736@3.36.224.80:26656,82f3085a83faa522c3cafa4e4dce1ef3a0c660f3@13.209.168.182:26656,f2b1ba3a684c4705aff7c01ec1c454a39794db5a@43.201.242.62:26656,bb98b9abd23a9d2e196b2c8a03cfb51a4bd49b47@43.202.78.165:26656,5606200cbdf662620625edea63b6a4275128fb34@3.38.254.221:26656,d76001510004c802fd2977488eb753ef261a245b@15.165.197.16:26656,e56dbf76c7b9508ecece447195382301e7c90ec7@52.78.154.236:26656,e772e1fb8c3492a9570a377a5eafdb1dc53cd778@54.194.245.5:26656,8ea4f592ad6cc38d7532aff418d1fb97052463af@34.240.245.39:26656,6726b826df45ac8e9afb4bdb2469c7771bd797f1@52.209.21.164:26656,ec59b724d669b9df205156e8fd457257116b1745@99.81.158.129:26656,08de3da03bd6774e4c5464dd29ddedddefbb1907@34.254.124.45:26656,78610e49cd8efb28c835c8478b30cf94650335b9@34.252.116.193:26656,e6816ab7fc88522be49940287206391bde87eeb9@54.76.109.39:26656,3215b1cf88ea913f477c0db0be00fb873d826d72@34.246.232.184:26656"|g' /var/lib/heimdall/config/config.toml
+  when: network == "mainnet"
+  become: true
+
+- name: update the persistent peers for mumbai heimdall
+  shell: sed -i 's|^persistent_peers =.*|persistent_peers = "1a3258eb2b69b235d4749cf9266a94567d6c0199@52.214.83.78:26656,758fc861495bc34d7b237d20a471b214c5cf7f14@34.240.114.47:26656,c76cbeeebeeae75bf04f5456691965bac8003ea3@54.170.47.95:26656,90fa880711cd3f410b63fa3fa51c9d5e9eb9f5bf@54.194.216.201:26656,9848f6a5e2f82363a1a1be82f9b4845de742207c@15.165.109.50:26656,5530873d889f0e694f0c29ead8d45eab20891440@3.37.26.115:26656,d3cf0d31b739277380fcef1e758917dcf37c25fb@43.201.135.93:26656,9df7ae4bf9b996c0e3436ed4cd3050dbc5742a28@43.200.206.40:26656,d9275750bc877b0276c374307f0fd7eae1d71e35@54.216.248.9:26656,f72ac90007cfb39bd1e4638669da3150533d38ec@143.110.185.126:26656"|g' /var/lib/heimdall/config/config.toml
+  when: network == "mumbai"
+  become: true
+
+- name: update heimdall inbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_inbound_peers =.*$'
+    line: 'max_num_inbound_peers = 100'
+    backrefs: yes
+  when: node_type == "sentry" or "archive"
+  become: true
+
+- name: update heimdall outbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_outbound_peers =.*$'
+    line: 'max_num_outbound_peers = 100'
+    backrefs: yes
+  when: node_type == "sentry" or "archive"
+  become: true
+
+- name: update heimdall inbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_inbound_peers =.*$'
+    line: 'max_num_inbound_peers = 50'
+    backrefs: yes
+  when: node_type == "validator"
+  become: true
+
+- name: update heimdall outbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_outbound_peers =.*$'
+    line: 'max_num_outbound_peers = 50'
+    backrefs: yes
+  when: node_type == "validator"
+  become: true
+
+- name: update heimdall inbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_inbound_peers =.*$'
+    line: 'max_num_inbound_peers = 200'
+    backrefs: yes
+  when: node_type == "bootnode"
+  become: true
+
+- name: update heimdall outbound peers
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^max_num_outbound_peers =.*$'
+    line: 'max_num_outbound_peers = 200'
+    backrefs: yes
+  when: node_type == "bootnode"
+  become: true
+
+- name: update heimdall external address
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^external_address =.*$'
+    line: 'external_address = "{{ ansible_host }}:26656"'
+    backrefs: yes
+  when: node_type == "sentry" or "archive" or "bootnode"
+  become: true
+
+- name: update heimdall external address
+  ansible.builtin.lineinfile:
+    path: /var/lib/heimdall/config/config.toml
+    regexp: '^external_address =.*$'
+    line: 'external_address = ""'
+    backrefs: yes
+  when: node_type == "validator"
+  become: true
+
 - name: start Heimdall service
   systemd:
     state: restarted
     daemon-reload: yes
     name: heimdalld.service
   become: yes
-
-

--- a/roles/install-heimdall/vars/main.yml
+++ b/roles/install-heimdall/vars/main.yml
@@ -4,5 +4,5 @@
 
 network: mainnet
 node_type: sentry
-bor_version: v0.3.0
-heimdall_version: v0.3.0
+bor_version: v1.2.3
+heimdall_version: v1.0.3

--- a/roles/node-exporter/tasks/main.yml
+++ b/roles/node-exporter/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Download binary of node-exporter
   get_url:
-    url: https://github.com/prometheus/node_exporter/releases/download/v0.18.1/node_exporter-0.18.1.linux-amd64.tar.gz
+    url: https://github.com/prometheus/node_exporter/releases/download/v1.7.0/node_exporter-1.7.0.linux-amd64.tar.gz
     dest: /tmp
 
 - name: Unarchive tar
   unarchive:
-    src: /tmp/node_exporter-0.18.1.linux-amd64.tar.gz
+    src: /tmp/node_exporter-1.7.0.linux-amd64.tar.gz
     dest: /tmp
     remote_src: yes
 
@@ -25,8 +25,8 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /tmp/node_exporter-0.18.1.linux-amd64.tar.gz
-    - /tmp/node_exporter-0.18.1.linux-amd64
+    - /tmp/node_exporter-1.7.0.linux-amd64.tar.gz
+    - /tmp/node_exporter-1.7.0.linux-amd64
 
 - name: Setup node exporter service
   copy:

--- a/roles/process-exporter/handlers/main.yml
+++ b/roles/process-exporter/handlers/main.yml
@@ -1,6 +1,5 @@
 ---
 # reload handlers
-
 - name: reload process-exporter
   systemd:
     name: process-exporter

--- a/roles/process-exporter/tasks/main.yml
+++ b/roles/process-exporter/tasks/main.yml
@@ -16,17 +16,17 @@
 
 - name: Copy the binary of process-exporter
   get_url:
-    url: https://github.com/ncabatoff/process-exporter/releases/download/v0.6.0/process-exporter-0.6.0.linux-amd64.tar.gz
+    url: https://github.com/ncabatoff/process-exporter/releases/download/v0.7.10/process-exporter-0.7.10.linux-amd64.tar.gz
     dest: /tmp
 
 - name: Download and unarchive tar
   unarchive:
-    src: /tmp/process-exporter-0.6.0.linux-amd64.tar.gz
+    src: /tmp/process-exporter-0.7.10.linux-amd64.tar.gz
     dest: /tmp
     remote_src: yes
 
 - name: Move process-exporter binary
-  command: mv /tmp/process-exporter-0.6.0.linux-amd64/process-exporter /usr/bin/
+  command: mv /tmp/process-exporter-0.7.10.linux-amd64/process-exporter /usr/bin/
   become: yes
 
 - name: Chown process-exporter
@@ -40,8 +40,8 @@
     path: "{{ item }}"
     state: absent
   with_items:
-    - /tmp/process-exporter-0.6.0.linux-amd64.tar.gz
-    - /tmp/process-exporter-0.6.0.linux-amd64
+    - /tmp/process-exporter-0.7.10.linux-amd64.tar.gz
+    - /tmp/process-exporter-0.7.10.linux-amd64
 
 - name: Setup process exporter service
   copy:

--- a/roles/snapshot-restore/files/snapshot_restore.sh
+++ b/roles/snapshot-restore/files/snapshot_restore.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+  function validate_network() {
+    if [[ "$1" != "mainnet" && "$1" != "mumbai" ]]; then
+      echo "Invalid network input. Please enter 'mainnet' or 'mumbai'."
+      exit 1
+    fi
+  }
+
+  function validate_client() {
+    if [[ "$1" != "heimdall" && "$1" != "bor" && "$1" != "erigon" ]]; then
+      echo "Invalid client input. Please enter 'heimdall' or 'bor' or 'erigon'."
+      exit 1
+    fi
+  }
+
+  function validate_checksum() {
+    if [[ "$1" != "true" && "$1" != "false" ]]; then
+      echo "Invalid checksum input. Please enter 'true' or 'false'."
+      exit 1
+    fi
+  }
+
+  # Parse command-line arguments
+  while [[ $# -gt 0 ]]; do
+    key="$1"
+
+    case $key in
+      -n | --network)
+        validate_network "$2"
+        network="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -c | --client)
+        validate_client "$2"
+        client="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -d | --extract-dir)
+        extract_dir="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      -v | --validate-checksum)
+        validate_checksum "$2"
+        checksum="$2"
+        shift # past argument
+        shift # past value
+        ;;
+      *) # unknown option
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+  done
+
+  # Set default values if not provided through command-line arguments
+  # as this is internal our values are always the same as they are
+  # derived from the mountpoints.
+  if [[ -z "$extract_dir_input" ]]; then
+  if [[ "$client" == "heimdall" ]]; then
+    extract_dir="/var/lib/heimdall/data"
+    elif [[ "$client" == "bor" ]]; then
+      extract_dir="/var/lib/bor/data/bor/chaindata"
+  fi
+  else
+    echo "Non supported custom script directory"
+    exit 1
+  fi
+
+  checksum=${checksum:-true}
+
+
+  # install dependencies and cursor to extract directory
+  sudo apt-get update -y
+  sudo apt-get install -y zstd pv aria2
+  mkdir -p "$extract_dir"
+  cd "$extract_dir"
+
+  # download compiled incremental snapshot files list
+  aria2c -x6 -s6 "https://snapshot-download.polygon.technology/$client-$network-parts.txt"
+
+  # remove hash lines if user declines checksum verification
+  if [ "$checksum" == "false" ]; then
+      sed -i '/checksum/d' $client-$network-parts.txt
+  fi
+
+  # download all incremental files, includes automatic checksum verification per increment
+  aria2c -x6 -s6 --max-tries=0 --save-session-interval=60 --save-session=$client-$network-failures.txt --max-connection-per-server=4 --retry-wait=3 --check-integrity=$checksum -i $client-$network-parts.txt
+
+  max_retries=5
+  retry_count=0
+
+  while [ $retry_count -lt $max_retries ]; do
+      echo "Retrying failed parts, attempt $((retry_count + 1))..."
+      aria2c -x6 -s6 --max-tries=0 --save-session-interval=60 --save-session=$client-$network-failures.txt --max-connection-per-server=4 --retry-wait=3 --check-integrity=$checksum -i $client-$network-failures.txt
+
+      # Check the exit status of the aria2c command
+      if [ $? -eq 0 ]; then
+          echo "Command succeeded."
+          break  # Exit the loop since the command succeeded
+      else
+          echo "Command failed. Retrying..."
+          retry_count=$((retry_count + 1))
+      fi
+  done
+
+  # Don't extract if download/retries failed.
+  if [ $retry_count -eq $max_retries ]; then
+      echo "Download failed. Restart the script to resume downloading."
+      exit 1
+  fi
+
+  declare -A processed_dates
+
+  # Join bulk parts into valid tar.zst and extract
+  for file in $(find . -name "$client-$network-snapshot-bulk-*-part-*" -print | sort); do
+      date_stamp=$(echo "$file" | grep -o 'snapshot-.*-part' | sed 's/snapshot-\(.*\)-part/\1/')
+
+      # Check if we have already processed this date
+      if [[ -z "${processed_dates[$date_stamp]}" ]]; then
+          processed_dates[$date_stamp]=1
+          output_tar="$client-$network-snapshot-${date_stamp}.tar.zst"
+          echo "Join parts for ${date_stamp} then extract"
+          cat $client-$network-snapshot-${date_stamp}-part* > "$output_tar"
+          rm $client-$network-snapshot-${date_stamp}-part*
+          pv $output_tar | tar -I zstd -xf - -C . && rm $output_tar
+      fi
+  done
+
+  # Join incremental following day parts
+  for file in $(find . -name "$client-$network-snapshot-*-part-*" -print | sort); do
+      date_stamp=$(echo "$file" | grep -o 'snapshot-.*-part' | sed 's/snapshot-\(.*\)-part/\1/')
+
+      # Check if we have already processed this date
+      if [[ -z "${processed_dates[$date_stamp]}" ]]; then
+          processed_dates[$date_stamp]=1
+          output_tar="$client-$network-snapshot-${date_stamp}.tar.zst"
+          echo "Join parts for ${date_stamp} then extract"
+          cat $client-$network-snapshot-${date_stamp}-part* > "$output_tar"
+          rm $client-$network-snapshot-${date_stamp}-part*
+          pv $output_tar | tar -I zstd -xf - -C . --strip-components=3 && rm $output_tar
+      fi
+  done

--- a/roles/snapshot-restore/tasks/main.yml
+++ b/roles/snapshot-restore/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Usage
+# ansible-playbook -i $inventory_file_of_your_choice.yml playbooks/snapshot_restore.yml -e "network=mumbai client=bor"
+# Supports mumbai and mainnet for networks, bor or heimdall as clients. erigon coming soon.
+- name: stop heimdall service
+  systemd:
+    state: stopped
+    daemon-reload: yes
+    name: heimdalld.service
+  when: client == "heimdall"
+  become: yes
+
+- name: stop bor service
+  systemd:
+    state: stopped
+    daemon-reload: yes
+    name: bor.service
+  when: client == "bor"
+  become: yes
+
+- name: removing existing data for {{ client }}
+  shell: sudo rm -rf /var/lib/bor/data/bor/chaindata
+  when: client == "bor"
+
+- name: removing existing data for {{ client }}
+  shell: sudo rm -rf /var/lib/heimdall/data/*
+  when: client == "heimdall"
+
+- name: Copy the script to the remote host
+  copy:
+    src: files/snapshot_restore.sh
+    dest: /home/ubuntu/snapshot_restore.sh
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+
+# Screen session has the {{ client_input }} so you can check the host with screen -r snapbor or screen -r snapheimdall in order to check status
+- name: Run the snapshot restore
+  shell: screen -dmS snap{{ client }} sudo /home/ubuntu/snapshot_restore.sh -n {{ network }} -c {{ client }}


### PR DESCRIPTION
Added snapshot restore playbook and role. See details in the playbook and role.
example:
ansible-playbook -i $inventory playbook/snapshot-restore.yml -e "network=$network client=$client"


Updated versions for node and process exporter to be used in the playbooks/role.

Updated the bor installer to include the following:
current bootnodes for mumbai/mainnet
current static-nodes for mumbai/mainnet
max peer recommendations for each type of node

Removed unnecessary installs in dependency install.

Updated the bor installer to include the following:
current seeds for mumbai/mainnet
current persistent peers for mumbai/mainnet
peer recommended settings for each type of node

Updated the default vars for bor and heimdall for current versions.

TODO:
Rewrite to the gcp installer is underway
Introduce arm64 for the exporters ( just need to finish testing ) 