### PR TITLE
Removing unnecessary startup commands

### DIFF
--- a/install-gcp.sh
+++ b/install-gcp.sh
@@ -148,8 +148,6 @@ function load_snapshots() {
 
 function polygonctl() {
   service heimdalld $1
-  service heimdalld-rest-server $1
-  service heimdalld-bridge $1
   service bor $1
 }
 


### PR DESCRIPTION
Removed the heimdalld-rest-server and heimdalld-bridge invocation, this is handled by the starting of heimdalld.