### PR TITLE
chg: bump go

### DIFF
--- a/go-install.sh
+++ b/go-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="1.20.7"
+VERSION="1.22.1"
 
 [ -z "$GOROOT" ] && GOROOT="$HOME/.go"
 [ -z "$GOPATH" ] && GOPATH="$HOME/go"


### PR DESCRIPTION
With this PR we update `go` version to `1.22.1` to make it compatible with `bor` after the latest commits on `develop`